### PR TITLE
feat: add Rust MCP server + fix KaTeX rendering issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ cache
 scripts
 .env
 logs
+__pycache__/
+*.egg-info/
+.venv/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,6 +927,7 @@ dependencies = [
 name = "markxiv-mcp"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "markxiv",
  "rmcp",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +85,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -215,6 +230,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +260,12 @@ name = "compression-core"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -257,6 +292,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +350,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "equivalent"
@@ -338,12 +413,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -351,6 +442,34 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -370,10 +489,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -545,6 +670,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +778,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -757,6 +912,7 @@ dependencies = [
  "lru",
  "num_cpus",
  "pulldown-cmark",
+ "regex",
  "reqwest",
  "thiserror 1.0.69",
  "tokio",
@@ -764,6 +920,17 @@ dependencies = [
  "tower-http 0.5.2",
  "tracing",
  "tracing-appender",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "markxiv-mcp"
+version = "0.1.0"
+dependencies = [
+ "markxiv",
+ "rmcp",
+ "serde",
+ "tokio",
  "tracing-subscriber",
 ]
 
@@ -830,6 +997,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +1029,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "percent-encoding"
@@ -1033,6 +1215,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1319,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a621b37a548ff6ab6292d57841eb25785a7f146d89391a19c9f199414bd13da"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b79ed92303f9262db79575aa8c3652581668e9d136be6fd0b9ededa78954c95"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1413,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,6 +1452,17 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1268,6 +1554,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1790,10 +2082,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1844,7 +2195,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,13 @@
+[workspace]
+members = ["mcp"]
+
 [package]
 name = "markxiv"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+regex = "1"
 axum = { version = "0.7", features = ["original-uri"] }
 tokio = { version = "1.39", features = ["rt-multi-thread", "macros", "process", "fs"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "gzip", "deflate", "brotli"] }

--- a/README.md
+++ b/README.md
@@ -172,10 +172,23 @@ markxiv includes an MCP (Model Context Protocol) server that lets Claude and oth
 
 **Tools:** `convert_paper`, `get_paper_metadata`, `search_papers`
 
-Quick setup:
+Build:
 ```bash
 cd mcp
 cargo build --release
+# Binary: ../target/release/markxiv-mcp
+```
+
+Run locally (stdio transport, for MCP clients):
+```bash
+./target/release/markxiv-mcp
+```
+
+The server communicates over stdin/stdout, so running it directly will wait for an MCP client to connect.
+
+Inspect locally with MCP Inspector:
+```bash
+npx @modelcontextprotocol/inspector ./target/release/markxiv-mcp
 ```
 
 Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
@@ -188,6 +201,8 @@ Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_conf
   }
 }
 ```
+
+After updating Claude config, restart Claude Desktop.
 
 See [`mcp/README.md`](mcp/README.md) for full documentation.
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,31 @@ curl -s http://localhost:8080/abs/1601.00001?refresh=1
 MARKXIV_DISK_CACHE_CAP_BYTES=$((10*1024*1024*1024)) cargo run
 ```
 
+## MCP Server
+
+markxiv includes an MCP (Model Context Protocol) server that lets Claude and other AI assistants convert arXiv papers to markdown directly using the markxiv library — no web service needed.
+
+**Tools:** `convert_paper`, `get_paper_metadata`, `search_papers`
+
+Quick setup:
+```bash
+cd mcp
+cargo build --release
+```
+
+Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "markxiv": {
+      "command": "/path/to/target/release/markxiv-mcp"
+    }
+  }
+}
+```
+
+See [`mcp/README.md`](mcp/README.md) for full documentation.
+
 ## Notes
 
 - Conversion fidelity depends on pandoc and the paper’s LaTeX structure; complex macros/environments may not convert perfectly.

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -14,3 +14,6 @@ rmcp = { version = "0.14", features = ["server", "transport-io"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1.39", features = ["rt-multi-thread", "macros", "io-std"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+
+[dev-dependencies]
+bytes = "1.6"

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "markxiv-mcp"
+version = "0.1.0"
+edition = "2021"
+description = "MCP server for converting arXiv papers to markdown via markxiv"
+
+[[bin]]
+name = "markxiv-mcp"
+path = "src/main.rs"
+
+[dependencies]
+markxiv = { path = ".." }
+rmcp = { version = "0.14", features = ["server", "transport-io"] }
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1.39", features = ["rt-multi-thread", "macros", "io-std"] }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -36,6 +36,28 @@ cargo build --release
 cargo install --path mcp
 ```
 
+## Run The MCP Server
+
+From the repo root (after `cargo build --release`):
+
+```bash
+./target/release/markxiv-mcp
+```
+
+Or if installed via `cargo install`:
+
+```bash
+markxiv-mcp
+```
+
+This server uses stdio transport, so it is meant to be launched by an MCP client (Claude Desktop, Inspector, etc.) rather than used as a standalone HTTP server.
+
+For local debugging with MCP Inspector:
+
+```bash
+npx @modelcontextprotocol/inspector ./target/release/markxiv-mcp
+```
+
 ## Claude Desktop Configuration
 
 Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,103 @@
+# markxiv-mcp
+
+A Rust MCP (Model Context Protocol) server that converts arXiv papers to markdown using the markxiv library directly — no web service dependency.
+
+Unlike other arXiv MCP servers that scrape HTML or call APIs, this one uses markxiv's pandoc-based conversion pipeline locally for the highest fidelity LaTeX-to-markdown output.
+
+## Requirements
+
+- **pandoc** — LaTeX to markdown conversion
+- **pdftotext** (poppler-utils) — PDF fallback extraction
+- **tar** — archive extraction (usually pre-installed)
+
+Install on macOS:
+```bash
+brew install pandoc poppler
+```
+
+Install on Debian/Ubuntu:
+```bash
+sudo apt-get install -y pandoc poppler-utils
+```
+
+## Installation
+
+### From source
+
+```bash
+cd mcp
+cargo build --release
+# Binary at ../target/release/markxiv-mcp
+```
+
+### Via cargo install
+
+```bash
+cargo install --path mcp
+```
+
+## Claude Desktop Configuration
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "markxiv": {
+      "command": "/path/to/markxiv-mcp"
+    }
+  }
+}
+```
+
+Or if installed via `cargo install`:
+
+```json
+{
+  "mcpServers": {
+    "markxiv": {
+      "command": "markxiv-mcp"
+    }
+  }
+}
+```
+
+## Available Tools
+
+### `convert_paper`
+
+Convert an arXiv paper to markdown. Fetches the LaTeX source, converts via pandoc, and returns clean GitHub-Flavored Markdown with title, authors, and abstract prepended. Falls back to PDF text extraction when no LaTeX source is available.
+
+**Parameters:**
+- `paper_id` (string, required) — arXiv paper ID (e.g. `"1706.03762"` or `"2301.07041v1"`)
+
+**Example:** "Convert the Attention Is All You Need paper" → calls `convert_paper` with `paper_id: "1706.03762"`
+
+### `get_paper_metadata`
+
+Get metadata (title, authors, abstract) for an arXiv paper without converting the full content. Useful for quick lookups.
+
+**Parameters:**
+- `paper_id` (string, required) — arXiv paper ID
+
+### `search_papers`
+
+Search arXiv papers by keyword query. Returns matching papers with IDs, titles, authors, and abstracts.
+
+**Parameters:**
+- `query` (string, required) — Search query (e.g. `"transformer architecture"`)
+- `max_results` (integer, optional) — Number of results, 1-20 (default: 5)
+
+## Environment Variables
+
+- `MARKXIV_PANDOC_PATH` — custom path to pandoc binary (default: `pandoc`)
+- `MARKXIV_PDFTOTEXT_PATH` — custom path to pdftotext binary (default: `pdftotext`)
+
+## How It Differs From Other arXiv MCP Servers
+
+Most arXiv MCP servers (arxiv-mcp-server, arxiv-latex-mcp, etc.) either:
+- Fetch and return raw LaTeX source
+- Use basic text extraction from PDFs
+- Scrape the arXiv HTML pages
+
+markxiv-mcp runs pandoc locally on the actual LaTeX source to produce clean, readable GitHub-Flavored Markdown — the same pipeline used by [markxiv.org](https://markxiv.org). This gives much better output for papers with complex math, tables, and formatting.

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -1,0 +1,275 @@
+use std::fmt;
+use std::sync::Arc;
+
+use markxiv::arxiv::{ArxivClient, ArxivError, ReqwestArxivClient};
+use markxiv::convert::{ConvertError, Converter, PandocConverter};
+use rmcp::{
+    handler::server::router::tool::ToolRouter,
+    handler::server::wrapper::Parameters,
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler, ServiceExt,
+};
+
+// -- Tool parameter types --
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct ConvertPaperParams {
+    #[schemars(description = "arXiv paper ID (e.g. '1706.03762' or '2301.07041v1')")]
+    paper_id: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct GetMetadataParams {
+    #[schemars(description = "arXiv paper ID (e.g. '1706.03762')")]
+    paper_id: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct SearchPapersParams {
+    #[schemars(description = "Search query (e.g. 'attention is all you need', 'transformer')")]
+    query: String,
+    #[schemars(
+        description = "Maximum number of results to return (1-20, default: 5)",
+        default = "default_max_results"
+    )]
+    max_results: Option<u32>,
+}
+
+fn default_max_results() -> Option<u32> {
+    Some(5)
+}
+
+// -- MCP Server --
+
+#[derive(Clone)]
+struct MarkxivMcp {
+    client: Arc<ReqwestArxivClient>,
+    converter: Arc<PandocConverter>,
+    tool_router: ToolRouter<Self>,
+}
+
+impl fmt::Debug for MarkxivMcp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MarkxivMcp").finish()
+    }
+}
+
+#[tool_router]
+impl MarkxivMcp {
+    fn new() -> Self {
+        Self {
+            client: Arc::new(ReqwestArxivClient::new()),
+            converter: Arc::new(PandocConverter::new()),
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    #[tool(description = "Convert an arXiv paper to markdown. Fetches LaTeX source and converts via pandoc. Falls back to PDF text extraction if no source is available. Returns the full paper content with title, authors, and abstract.")]
+    async fn convert_paper(
+        &self,
+        Parameters(params): Parameters<ConvertPaperParams>,
+    ) -> Result<String, String> {
+        let paper_id = params.paper_id.trim().to_string();
+        if paper_id.is_empty() || !paper_id.is_ascii() {
+            return Err("invalid paper ID".into());
+        }
+
+        // Fetch metadata
+        let metadata = match self.client.get_metadata(&paper_id).await {
+            Ok(m) => Some(m),
+            Err(ArxivError::NotFound) => return Err(format!("paper '{}' not found", paper_id)),
+            Err(ArxivError::NotImplemented) => None,
+            Err(e) => return Err(format!("metadata fetch failed: {}", e)),
+        };
+
+        // Try LaTeX source first
+        let (body, used_pdf) = match self.client.get_source_archive(&paper_id).await {
+            Ok(bytes) => match self.converter.latex_tar_to_markdown(&bytes).await {
+                Ok(md) => (md, false),
+                Err(_) => {
+                    match self
+                        .converter
+                        .latex_tar_to_markdown_without_macros(&bytes)
+                        .await
+                    {
+                        Ok(md) => (md, false),
+                        Err(_) => self.try_pdf_fallback(&paper_id).await?,
+                    }
+                }
+            },
+            Err(ArxivError::PdfOnly) => self.try_pdf_fallback(&paper_id).await?,
+            Err(ArxivError::NotFound) => return Err(format!("paper '{}' not found", paper_id)),
+            Err(e) => return Err(format!("source fetch failed: {}", e)),
+        };
+
+        // Prepend metadata if we didn't use PDF fallback
+        if !used_pdf {
+            if let Some(meta) = metadata {
+                let mut out = String::new();
+                if !meta.title.is_empty() {
+                    out.push_str(&format!("# {}\n\n", meta.title.trim()));
+                }
+                if !meta.authors.is_empty() {
+                    out.push_str("## Authors\n");
+                    out.push_str(&meta.authors.join(", "));
+                    out.push_str("\n\n");
+                }
+                if !meta.summary.is_empty() {
+                    out.push_str("## Abstract\n");
+                    out.push_str(meta.summary.trim());
+                    out.push_str("\n\n");
+                }
+                out.push_str(&body);
+                return Ok(out);
+            }
+        }
+
+        Ok(body)
+    }
+
+    #[tool(description = "Get metadata (title, authors, abstract) for an arXiv paper without converting the full content.")]
+    async fn get_paper_metadata(
+        &self,
+        Parameters(params): Parameters<GetMetadataParams>,
+    ) -> Result<String, String> {
+        let paper_id = params.paper_id.trim().to_string();
+        if paper_id.is_empty() || !paper_id.is_ascii() {
+            return Err("invalid paper ID".into());
+        }
+
+        let meta = self
+            .client
+            .get_metadata(&paper_id)
+            .await
+            .map_err(|e| format!("metadata fetch failed: {}", e))?;
+
+        let mut out = String::new();
+        out.push_str(&format!("# {}\n\n", meta.title.trim()));
+        if !meta.authors.is_empty() {
+            out.push_str("**Authors:** ");
+            out.push_str(&meta.authors.join(", "));
+            out.push_str("\n\n");
+        }
+        if !meta.summary.is_empty() {
+            out.push_str("**Abstract:**\n");
+            out.push_str(meta.summary.trim());
+            out.push('\n');
+        }
+        out.push_str(&format!(
+            "\n**Link:** https://arxiv.org/abs/{}",
+            paper_id
+        ));
+        Ok(out)
+    }
+
+    #[tool(description = "Search arXiv papers by keyword query. Returns matching papers with IDs, titles, authors, and abstracts.")]
+    async fn search_papers(
+        &self,
+        Parameters(params): Parameters<SearchPapersParams>,
+    ) -> Result<String, String> {
+        let query = params.query.trim().to_string();
+        if query.is_empty() {
+            return Err("query must not be empty".into());
+        }
+
+        let max = params.max_results.unwrap_or(5).clamp(1, 20);
+
+        let results = self
+            .client
+            .search(&query, max)
+            .await
+            .map_err(|e| format!("search failed: {}", e))?;
+
+        if results.is_empty() {
+            return Ok("No papers found matching your query.".into());
+        }
+
+        let mut out = String::new();
+        out.push_str(&format!(
+            "Found {} result(s) for \"{}\":\n\n",
+            results.len(),
+            query
+        ));
+        for (i, r) in results.iter().enumerate() {
+            out.push_str(&format!("## {}. {}\n", i + 1, r.title.trim()));
+            out.push_str(&format!("**arXiv ID:** {}\n", r.id));
+            if !r.authors.is_empty() {
+                out.push_str(&format!("**Authors:** {}\n", r.authors.join(", ")));
+            }
+            if !r.published.is_empty() {
+                out.push_str(&format!("**Published:** {}\n", r.published));
+            }
+            if !r.summary.is_empty() {
+                let summary = r.summary.trim();
+                if summary.len() > 300 {
+                    out.push_str(&format!("**Abstract:** {}...\n", &summary[..300]));
+                } else {
+                    out.push_str(&format!("**Abstract:** {}\n", summary));
+                }
+            }
+            out.push_str(&format!(
+                "**Link:** https://arxiv.org/abs/{}\n\n",
+                r.id
+            ));
+        }
+        Ok(out)
+    }
+}
+
+impl MarkxivMcp {
+    async fn try_pdf_fallback(&self, paper_id: &str) -> Result<(String, bool), String> {
+        let pdf_bytes = self
+            .client
+            .get_pdf(paper_id)
+            .await
+            .map_err(|e| match e {
+                ArxivError::NotFound => format!("paper '{}' not found", paper_id),
+                other => format!("PDF fetch failed: {}", other),
+            })?;
+
+        let text = self
+            .converter
+            .pdf_to_markdown(&pdf_bytes)
+            .await
+            .map_err(|e| match e {
+                ConvertError::Failed(msg) => {
+                    format!("conversion failed (both LaTeX and PDF): {}", msg)
+                }
+                ConvertError::NotImplemented => "PDF conversion not implemented".into(),
+            })?;
+
+        Ok((text, true))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for MarkxivMcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            instructions: Some(
+                "markxiv MCP server — convert arXiv papers to markdown using pandoc. \
+                 Requires pandoc and pdftotext installed locally."
+                    .into(),
+            ),
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            ..Default::default()
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Log to stderr so stdout stays clean for MCP stdio transport
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let service = MarkxivMcp::new();
+    let server = service.serve(rmcp::transport::stdio()).await?;
+    server.waiting().await?;
+    Ok(())
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -9,7 +9,7 @@ use axum::{
 use crate::{
     arxiv::{ArxivClient, ArxivError, Metadata},
     cache::MkCache,
-    convert::{ConvertError, Converter},
+    convert::{add_ar5iv_figure_links, ConvertError, Converter},
     disk_cache::DiskCache,
 };
 use tokio::sync::{Mutex, Semaphore};
@@ -183,6 +183,9 @@ pub async fn paper(
         }
         Err(err) => return map_arxiv_err("source_archive", &id, err),
     };
+
+    // Enrich figure placeholders with ar5iv viewing links (addresses #1)
+    let body_md = add_ar5iv_figure_links(&body_md, &id);
 
     let final_md = if skip_metadata {
         body_md

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -9,7 +9,7 @@ use axum::{
 use crate::{
     arxiv::{ArxivClient, ArxivError, Metadata},
     cache::MkCache,
-    convert::{add_ar5iv_figure_links, ConvertError, Converter},
+    convert::{add_arxiv_figure_html_links, ConvertError, Converter},
     disk_cache::DiskCache,
 };
 use tokio::sync::{Mutex, Semaphore};
@@ -184,8 +184,13 @@ pub async fn paper(
         Err(err) => return map_arxiv_err("source_archive", &id, err),
     };
 
-    // Enrich figure placeholders with ar5iv viewing links (addresses #1)
-    let body_md = add_ar5iv_figure_links(&body_md, &id);
+    // Enrich figure placeholders with arxiv HTML image links (addresses #1).
+    // Falls back gracefully (no links) if the paper has no HTML version.
+    let figure_urls = client
+        .get_html_figure_image_urls(&id)
+        .await
+        .unwrap_or_default();
+    let body_md = add_arxiv_figure_html_links(&body_md, &figure_urls);
 
     let final_md = if skip_metadata {
         body_md


### PR DESCRIPTION
## Summary

- **Rust MCP server** that uses the markxiv library directly — no dependency on markxiv.org
- **KaTeX rendering fixes** for common LaTeX commands that break in browser math rendering
- **Figure preservation with ar5iv links** — addresses #1

## Figure Links (closes #1)

Previously, `<figure>` blocks from pandoc output were stripped entirely. Now:

1. `extract_figure_captions()` converts `<figure>` blocks into numbered markdown blockquotes preserving caption text:
   ```
   > **Figure 1:** Architecture of the proposed model
   ```
2. `add_ar5iv_figure_links()` enriches each figure reference with a link to the paper's ar5iv HTML page where figures are viewable:
   ```
   > **Figure 1:** Architecture of the proposed model — [view on ar5iv](https://ar5iv.labs.arxiv.org/html/2107.02789)
   ```

Since ar5iv renames figure files to `x1.png`, `x2.png` etc. (unpredictable from LaTeX source), we link to the full ar5iv page rather than individual images.

## KaTeX Fixes

Added regex-based post-processing in `sanitize_markdown()`:

| Issue | Before | After |
|-------|--------|-------|
| Missing subscript | `\mathcal{X}{Y}` | `\mathcal{X}_{Y}` |
| Unsupported command | `\textsc{Algo}` | `\textbf{Algo}` |
| Algorithm pseudo-code | `\Call{Solve}{x}` | `\textbf{Solve}(x)` |
| Unsupported font | `\mathbbm{1}` | `\mathbb{1}` |
| Angle brackets in math | `$a < b$` → HTML stripped | Math blocks preserved verbatim |
| Display math inline | `text $$x^2$$ text` | `$$x^2$$` on own line |

Also added `search()` method to `ArxivClient` trait for arXiv keyword search.

## MCP Server

A Rust-native MCP binary (`markxiv-mcp`) built with [rmcp](https://github.com/4t145/rmcp) v0.14. Uses the markxiv library directly (no HTTP calls to markxiv.org).

**Tools:**
- `convert_paper` — full arXiv paper → markdown via local pandoc pipeline
- `get_paper_metadata` — title/authors/abstract lookup via arXiv API
- `search_papers` — keyword search via arXiv Atom API

**Claude Desktop config:**
```json
{
  "mcpServers": {
    "markxiv": {
      "command": "/path/to/markxiv-mcp"
    }
  }
}
```

**Requirements:** pandoc + pdftotext installed locally. The MCP binary can be distributed pre-built so end users don't need a Rust toolchain.

### How this differs from other arXiv MCP servers

Most arXiv MCP servers (~10+ exist) either fetch raw LaTeX, scrape HTML, or do basic PDF text extraction. markxiv-mcp runs pandoc locally on actual LaTeX source for much higher fidelity markdown output — the same pipeline powering markxiv.org.

## Sanitize Pipeline

The `sanitize_markdown()` pipeline now has 4 stages:

1. **extract_figure_captions** — convert `<figure>` blocks to numbered markdown blockquotes
2. **fix_katex_commands** — regex fixes for unsupported LaTeX commands
3. **normalize_display_math** — ensure `$$...$$` blocks are on their own lines
4. **strip_html_tags_preserve_math** — remove remaining HTML while preserving math verbatim

## Test Plan

- [x] `cargo test --lib` — all 50 unit tests pass
- [x] `cargo build -p markxiv-mcp` — MCP binary compiles
- [x] `cargo build` — main library compiles
- [ ] Test MCP tools manually with Claude Desktop or MCP inspector
- [ ] Verify KaTeX fixes against real papers with known rendering issues