### PR TITLE
add biorxiv provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,22 @@ Just replace 'arxiv' in the URL with 'markxiv' to get the markdown
 
 https://arxiv.org/abs/1706.03762 → https://markxiv.org/abs/1706.03762
 
+bioRxiv is also supported through the `/bio/` route family:
+
+https://www.biorxiv.org/content/10.1101/2024.01.02.123456v1.full → https://markxiv.org/bio/10.1101/2024.01.02.123456v1.full
+
 ## Basics
 
 A minimal web service that mimics arXiv but serves Markdown instead of PDFs/HTML.
 
-Given an arXiv ID, the server:
+Given an arXiv or bioRxiv paper identifier, the server:
 - Checks a local LRU cache for a converted result
-- Fetches the paper’s LaTeX source from arXiv (if available)
+- Fetches the paper’s LaTeX source when available
 - Extracts the archive, picks the main `.tex` file, converts it to Markdown using pandoc
 - Falls back to `pdftotext` when LaTeX sources are unavailable or pandoc conversion fails
 - Returns `text/markdown; charset=utf-8`
 
-If a paper is PDF-only (no source available) or pandoc conversion fails, the server falls back to `pdftotext` and returns the extracted Markdown/plain text when that succeeds.
+If a paper is PDF-only (no source available) or pandoc conversion fails, the server falls back to `pdftotext` and returns the extracted Markdown/plain text when that succeeds. bioRxiv currently uses that PDF-first path by design.
 
 Returned Markdown includes the paper title and abstract prepended at the top.
 
@@ -112,11 +116,15 @@ Environment variables:
   - Two-tier caching: in-memory LRU first, then on-disk gzip store; cache populated on miss
 - `GET /pdf/:id[?refresh=1]` → same response as `/abs/:id`, useful for links that expect the `/pdf/` prefix
   - Requests like `/pdf/:id.pdf` are normalized automatically
+- `GET /bio/*id[?refresh=1]` → bioRxiv conversion endpoint with `text/markdown`
+  - Accepts canonical bioRxiv identifiers such as `10.1101/2024.01.02.123456v1`, plus `.full` and `.full.pdf` variants
+  - Uses a wildcard route because bioRxiv identifiers contain `/`
+  - Uses the same cache/conversion pipeline as arXiv, but bioRxiv is currently PDF-first
 
 Error mapping:
-- `404 Not Found` — unknown arXiv id
+- `404 Not Found` — unknown paper id at the selected provider
 - `422 Unprocessable Entity` — PDF only (no e-print source) and the `pdftotext` fallback also failed
-- `502 Bad Gateway` — upstream/network error contacting arXiv
+- `502 Bad Gateway` — upstream/network error contacting the paper provider
 - `500 Internal Server Error` — conversion/extraction errors
 
 ## Development
@@ -131,14 +139,17 @@ Project layout:
 - `src/routes.rs` — handlers (`/`, `/health`, `/abs/:id`, `/pdf/:id`)
 - `src/state.rs` — shared state (LRU cache + clients)
 - `src/cache.rs` — thin wrapper around `lru::LruCache`
-- `src/arxiv.rs` — arXiv client + metadata fetch via Atom API
+- `src/arxiv.rs` — arXiv client + shared paper-source abstractions
+- `src/biorxiv.rs` — bioRxiv client + identifier normalization
 - `src/convert.rs` — pandoc-based converter + sanitization
 - `src/tex_main.rs` — heuristic for picking the main `.tex` file
 
 ### How it works
 
-- Metadata (title, abstract): `https://export.arxiv.org/api/query?id_list=:id` (Atom feed), minimal parse of `<entry><title>` and `<summary>`.
-- Source archive: `https://arxiv.org/e-print/:id` (tar/tar.gz). 400/403/404 → treated as PDF-only.
+- arXiv metadata (title, abstract): `https://export.arxiv.org/api/query?id_list=:id` (Atom feed), minimal parse of `<entry><title>` and `<summary>`.
+- arXiv source archive: `https://arxiv.org/e-print/:id` (tar/tar.gz). 400/403/404 → treated as PDF-only.
+- bioRxiv metadata: article-page meta tags on `https://www.biorxiv.org/content/:id.full`.
+- bioRxiv source policy: PDF-first. The server does not currently assume a LaTeX source archive exists upstream.
 - Conversion: save archive to temp dir → extract with `tar` → pick main `.tex` → `pandoc -f latex -t gfm` → sanitize.
 - Fallback: when LaTeX sources are unavailable or pandoc fails, download the PDF and shell out to `pdftotext -raw`.
 - Sanitization: remove entire `<figure>...</figure>` blocks and strip all remaining HTML tags from the Markdown output.
@@ -159,6 +170,9 @@ curl -sH 'Accept: text/markdown' http://localhost:8080/
 # fetch a paper (replace with a source-available id)
 curl -sH 'Accept: text/markdown' http://localhost:8080/abs/1601.00001
 
+# fetch a bioRxiv paper
+curl -sH 'Accept: text/markdown' http://localhost:8080/bio/10.1101/2024.01.02.123456v1.full
+
 # force refresh (bypass cache)
 curl -s http://localhost:8080/abs/1601.00001?refresh=1
 
@@ -168,9 +182,11 @@ MARKXIV_DISK_CACHE_CAP_BYTES=$((10*1024*1024*1024)) cargo run
 
 ## MCP Server
 
-markxiv includes an MCP (Model Context Protocol) server that lets Claude and other AI assistants convert arXiv papers to markdown directly using the markxiv library — no web service needed.
+markxiv includes an MCP (Model Context Protocol) server that lets Claude and other AI assistants convert arXiv and bioRxiv papers to markdown directly using the markxiv library — no web service needed.
 
 **Tools:** `convert_paper`, `get_paper_metadata`, `search_papers`
+
+`search_papers` remains arXiv-only in this phase.
 
 Build:
 ```bash

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,6 @@
 # markxiv-mcp
 
-A Rust MCP (Model Context Protocol) server that converts arXiv papers to markdown using the markxiv library directly — no web service dependency.
+A Rust MCP (Model Context Protocol) server that converts arXiv and bioRxiv papers to markdown using the markxiv library directly — no web service dependency.
 
 Unlike other arXiv MCP servers that scrape HTML or call APIs, this one uses markxiv's pandoc-based conversion pipeline locally for the highest fidelity LaTeX-to-markdown output.
 
@@ -88,23 +88,31 @@ Or if installed via `cargo install`:
 
 ### `convert_paper`
 
-Convert an arXiv paper to markdown. Fetches the LaTeX source, converts via pandoc, and returns clean GitHub-Flavored Markdown with title, authors, and abstract prepended. Falls back to PDF text extraction when no LaTeX source is available.
+Convert an arXiv or bioRxiv paper to markdown. markxiv prefers LaTeX source when available and falls back to PDF text extraction when no source is available. bioRxiv currently uses the PDF-first path.
 
 **Parameters:**
-- `paper_id` (string, required) — arXiv paper ID (e.g. `"1706.03762"` or `"2301.07041v1"`)
+- `paper_id` (string, required) — paper ID or URL
+- `provider` (string, optional) — `"arxiv"` or `"biorxiv"`; usually unnecessary because the server can infer the provider from the input
 
-**Example:** "Convert the Attention Is All You Need paper" → calls `convert_paper` with `paper_id: "1706.03762"`
+Accepted examples:
+- `"1706.03762"`
+- `"https://arxiv.org/abs/1706.03762"`
+- `"10.1101/2024.01.02.123456v1.full.pdf"`
+- `"https://www.biorxiv.org/content/10.1101/2024.01.02.123456v1.full"`
 
 ### `get_paper_metadata`
 
-Get metadata (title, authors, abstract) for an arXiv paper without converting the full content. Useful for quick lookups.
+Get metadata (title, authors, abstract) for an arXiv or bioRxiv paper without converting the full content. Useful for quick lookups.
 
 **Parameters:**
-- `paper_id` (string, required) — arXiv paper ID
+- `paper_id` (string, required) — paper ID or URL
+- `provider` (string, optional) — `"arxiv"` or `"biorxiv"`
 
 ### `search_papers`
 
 Search arXiv papers by keyword query. Returns matching papers with IDs, titles, authors, and abstracts.
+
+This tool remains arXiv-only.
 
 **Parameters:**
 - `query` (string, required) — Search query (e.g. `"transformer architecture"`)

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -1,7 +1,10 @@
 use std::fmt;
 use std::sync::Arc;
 
-use markxiv::arxiv::{ArxivClient, ArxivError, ReqwestArxivClient};
+use markxiv::arxiv::{
+    normalize_arxiv_id, ArxivClient, ArxivError, PaperSource, ReqwestArxivClient,
+};
+use markxiv::biorxiv::{biorxiv_article_url, normalize_biorxiv_id, ReqwestBiorxivClient};
 use markxiv::convert::{ConvertError, Converter, PandocConverter};
 use rmcp::{
     handler::server::router::tool::ToolRouter,
@@ -14,14 +17,18 @@ use rmcp::{
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 struct ConvertPaperParams {
-    #[schemars(description = "arXiv paper ID (e.g. '1706.03762' or '2301.07041v1')")]
+    #[schemars(description = "Paper ID or URL. Supports arXiv IDs/URLs and bioRxiv IDs/URLs.")]
     paper_id: String,
+    #[schemars(description = "Optional provider override: 'arxiv' or 'biorxiv'")]
+    provider: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 struct GetMetadataParams {
-    #[schemars(description = "arXiv paper ID (e.g. '1706.03762')")]
+    #[schemars(description = "Paper ID or URL. Supports arXiv IDs/URLs and bioRxiv IDs/URLs.")]
     paper_id: String,
+    #[schemars(description = "Optional provider override: 'arxiv' or 'biorxiv'")]
+    provider: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -43,7 +50,8 @@ fn default_max_results() -> Option<u32> {
 
 #[derive(Clone)]
 struct MarkxivMcp {
-    client: Arc<ReqwestArxivClient>,
+    arxiv_client: Arc<ReqwestArxivClient>,
+    biorxiv_client: Arc<ReqwestBiorxivClient>,
     converter: Arc<PandocConverter>,
     tool_router: ToolRouter<Self>,
 }
@@ -58,32 +66,32 @@ impl fmt::Debug for MarkxivMcp {
 impl MarkxivMcp {
     fn new() -> Self {
         Self {
-            client: Arc::new(ReqwestArxivClient::new()),
+            arxiv_client: Arc::new(ReqwestArxivClient::new()),
+            biorxiv_client: Arc::new(ReqwestBiorxivClient::new()),
             converter: Arc::new(PandocConverter::new()),
             tool_router: Self::tool_router(),
         }
     }
 
-    #[tool(description = "Convert an arXiv paper to markdown. Returns the full paper content with title, authors, and abstract.")]
+    #[tool(
+        description = "Convert an arXiv or bioRxiv paper to markdown. Returns the full paper content with title, authors, and abstract when available."
+    )]
     async fn convert_paper(
         &self,
         Parameters(params): Parameters<ConvertPaperParams>,
     ) -> Result<String, String> {
-        let paper_id = params.paper_id.trim().to_string();
-        if paper_id.is_empty() || !paper_id.is_ascii() {
-            return Err("invalid paper ID".into());
-        }
+        let resolved = resolve_paper_input(&params.paper_id, params.provider.as_deref())?;
 
-        // Fetch metadata
-        let metadata = match self.client.get_metadata(&paper_id).await {
+        let (client, paper_id) = self.provider_client(&resolved);
+
+        let metadata = match client.get_metadata(&paper_id).await {
             Ok(m) => Some(m),
             Err(ArxivError::NotFound) => return Err(format!("paper '{}' not found", paper_id)),
             Err(ArxivError::NotImplemented) => None,
             Err(e) => return Err(format!("metadata fetch failed: {}", e)),
         };
 
-        // Try LaTeX source first
-        let (body, used_pdf) = match self.client.get_source_archive(&paper_id).await {
+        let (body, used_pdf) = match client.get_source_archive(&paper_id).await {
             Ok(bytes) => match self.converter.latex_tar_to_markdown(&bytes).await {
                 Ok(md) => (md, false),
                 Err(_) => {
@@ -93,11 +101,11 @@ impl MarkxivMcp {
                         .await
                     {
                         Ok(md) => (md, false),
-                        Err(_) => self.try_pdf_fallback(&paper_id).await?,
+                        Err(_) => self.try_pdf_fallback(&resolved).await?,
                     }
                 }
             },
-            Err(ArxivError::PdfOnly) => self.try_pdf_fallback(&paper_id).await?,
+            Err(ArxivError::PdfOnly) => self.try_pdf_fallback(&resolved).await?,
             Err(ArxivError::NotFound) => return Err(format!("paper '{}' not found", paper_id)),
             Err(e) => return Err(format!("source fetch failed: {}", e)),
         };
@@ -127,18 +135,17 @@ impl MarkxivMcp {
         Ok(body)
     }
 
-    #[tool(description = "Get metadata (title, authors, abstract) for an arXiv paper without converting the full content.")]
+    #[tool(
+        description = "Get metadata (title, authors, abstract) for an arXiv or bioRxiv paper without converting the full content."
+    )]
     async fn get_paper_metadata(
         &self,
         Parameters(params): Parameters<GetMetadataParams>,
     ) -> Result<String, String> {
-        let paper_id = params.paper_id.trim().to_string();
-        if paper_id.is_empty() || !paper_id.is_ascii() {
-            return Err("invalid paper ID".into());
-        }
+        let resolved = resolve_paper_input(&params.paper_id, params.provider.as_deref())?;
+        let (client, paper_id) = self.provider_client(&resolved);
 
-        let meta = self
-            .client
+        let meta = client
             .get_metadata(&paper_id)
             .await
             .map_err(|e| format!("metadata fetch failed: {}", e))?;
@@ -155,14 +162,13 @@ impl MarkxivMcp {
             out.push_str(meta.summary.trim());
             out.push('\n');
         }
-        out.push_str(&format!(
-            "\n**Link:** https://arxiv.org/abs/{}",
-            paper_id
-        ));
+        out.push_str(&format!("\n**Link:** {}", resolved.public_link()));
         Ok(out)
     }
 
-    #[tool(description = "Search arXiv papers by keyword query. Returns matching papers with IDs, titles, authors, and abstracts.")]
+    #[tool(
+        description = "Search arXiv papers by keyword query. Returns matching papers with IDs, titles, authors, and abstracts."
+    )]
     async fn search_papers(
         &self,
         Parameters(params): Parameters<SearchPapersParams>,
@@ -175,7 +181,7 @@ impl MarkxivMcp {
         let max = params.max_results.unwrap_or(5).clamp(1, 20);
 
         let results = self
-            .client
+            .arxiv_client
             .search(&query, max)
             .await
             .map_err(|e| format!("search failed: {}", e))?;
@@ -207,25 +213,29 @@ impl MarkxivMcp {
                     out.push_str(&format!("**Abstract:** {}\n", summary));
                 }
             }
-            out.push_str(&format!(
-                "**Link:** https://arxiv.org/abs/{}\n\n",
-                r.id
-            ));
+            out.push_str(&format!("**Link:** https://arxiv.org/abs/{}\n\n", r.id));
         }
         Ok(out)
     }
 }
 
 impl MarkxivMcp {
-    async fn try_pdf_fallback(&self, paper_id: &str) -> Result<(String, bool), String> {
-        let pdf_bytes = self
-            .client
-            .get_pdf(paper_id)
-            .await
-            .map_err(|e| match e {
-                ArxivError::NotFound => format!("paper '{}' not found", paper_id),
-                other => format!("PDF fetch failed: {}", other),
-            })?;
+    fn provider_client(
+        &self,
+        resolved: &ResolvedPaper,
+    ) -> (&(dyn ArxivClient + Send + Sync), String) {
+        match resolved.provider {
+            Provider::Arxiv => (self.arxiv_client.as_ref(), resolved.paper_id.clone()),
+            Provider::Biorxiv => (self.biorxiv_client.as_ref(), resolved.paper_id.clone()),
+        }
+    }
+
+    async fn try_pdf_fallback(&self, resolved: &ResolvedPaper) -> Result<(String, bool), String> {
+        let (client, paper_id) = self.provider_client(resolved);
+        let pdf_bytes = client.get_pdf(&paper_id).await.map_err(|e| match e {
+            ArxivError::NotFound => format!("paper '{}' not found", paper_id),
+            other => format!("PDF fetch failed: {}", other),
+        })?;
 
         let text = self
             .converter
@@ -239,6 +249,69 @@ impl MarkxivMcp {
             })?;
 
         Ok((text, true))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Provider {
+    Arxiv,
+    Biorxiv,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ResolvedPaper {
+    provider: Provider,
+    paper_id: String,
+}
+
+impl ResolvedPaper {
+    fn public_link(&self) -> String {
+        match self.provider {
+            Provider::Arxiv => format!("https://arxiv.org/abs/{}", self.paper_id),
+            Provider::Biorxiv => biorxiv_article_url(&self.paper_id),
+        }
+    }
+}
+
+fn resolve_paper_input(input: &str, provider_hint: Option<&str>) -> Result<ResolvedPaper, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("invalid paper ID".into());
+    }
+
+    match provider_hint.map(|s| s.trim().to_ascii_lowercase()) {
+        Some(provider) if provider == "arxiv" => {
+            let paper_id =
+                normalize_arxiv_id(trimmed).ok_or_else(|| "invalid arXiv paper ID".to_string())?;
+            Ok(ResolvedPaper {
+                provider: Provider::Arxiv,
+                paper_id,
+            })
+        }
+        Some(provider) if provider == "biorxiv" => {
+            let paper_id = normalize_biorxiv_id(trimmed)
+                .ok_or_else(|| "invalid bioRxiv paper ID".to_string())?;
+            Ok(ResolvedPaper {
+                provider: Provider::Biorxiv,
+                paper_id,
+            })
+        }
+        Some(_) => Err("unsupported provider; use 'arxiv' or 'biorxiv'".into()),
+        None => {
+            if let Some(paper_id) = normalize_biorxiv_id(trimmed) {
+                return Ok(ResolvedPaper {
+                    provider: Provider::Biorxiv,
+                    paper_id,
+                });
+            }
+            if let Some(paper_id) = normalize_arxiv_id(trimmed) {
+                return Ok(ResolvedPaper {
+                    provider: Provider::Arxiv,
+                    paper_id,
+                });
+            }
+            Err("invalid paper ID".into())
+        }
     }
 }
 
@@ -261,7 +334,7 @@ impl ServerHandler for MarkxivMcp {
 mod tests {
     use bytes::Bytes;
     use markxiv::arxiv::test_helpers::MockArxivClient;
-    use markxiv::arxiv::{ArxivClient, ArxivError, Metadata, SearchResult};
+    use markxiv::arxiv::{ArxivClient, ArxivError, Metadata, PaperSource, SearchResult};
     use markxiv::convert::test_helpers::MockConverter;
     use markxiv::convert::Converter;
 
@@ -477,14 +550,41 @@ mod tests {
         for (i, r) in results.iter().enumerate() {
             out.push_str(&format!("## {}. {}\n", i + 1, r.title.trim()));
             out.push_str(&format!("**arXiv ID:** {}\n", r.id));
-            out.push_str(&format!(
-                "**Link:** https://arxiv.org/abs/{}\n\n",
-                r.id
-            ));
+            out.push_str(&format!("**Link:** https://arxiv.org/abs/{}\n\n", r.id));
         }
         assert!(out.contains("## 1. Attention Is All You Need"));
         assert!(out.contains("**arXiv ID:** 1706.03762v5"));
         assert!(out.contains("## 2. Another Paper"));
+    }
+
+    #[test]
+    fn resolve_paper_input_detects_biorxiv_url() {
+        let resolved = super::resolve_paper_input(
+            "https://www.biorxiv.org/content/10.1101/2024.01.02.123456v1.full.pdf",
+            None,
+        )
+        .unwrap();
+        assert_eq!(resolved.provider, super::Provider::Biorxiv);
+        assert_eq!(resolved.paper_id, "10.1101/2024.01.02.123456v1");
+    }
+
+    #[test]
+    fn resolve_paper_input_respects_provider_override() {
+        let resolved = super::resolve_paper_input("1706.03762", Some("arxiv")).unwrap();
+        assert_eq!(resolved.provider, super::Provider::Arxiv);
+        assert_eq!(resolved.paper_id, "1706.03762");
+    }
+
+    #[test]
+    fn resolved_paper_public_link_uses_provider() {
+        let resolved = super::ResolvedPaper {
+            provider: super::Provider::Biorxiv,
+            paper_id: "10.1101/2024.01.02.123456v1".into(),
+        };
+        assert_eq!(
+            resolved.public_link(),
+            "https://www.biorxiv.org/content/10.1101/2024.01.02.123456v1.full"
+        );
     }
 }
 

--- a/src/arxiv.rs
+++ b/src/arxiv.rs
@@ -4,7 +4,7 @@ use reqwest::Url;
 use thiserror::Error;
 
 #[derive(Clone, Debug, Error)]
-pub enum ArxivError {
+pub enum PaperSourceError {
     #[error("not found")]
     NotFound,
     #[error("pdf only")]
@@ -15,24 +15,30 @@ pub enum ArxivError {
     NotImplemented,
 }
 
+pub type ArxivError = PaperSourceError;
+
 #[async_trait]
-pub trait ArxivClient {
-    async fn exists(&self, id: &str) -> Result<bool, ArxivError>;
-    async fn get_source_archive(&self, id: &str) -> Result<Bytes, ArxivError>;
-    async fn get_pdf(&self, id: &str) -> Result<Bytes, ArxivError>;
-    async fn get_metadata(&self, id: &str) -> Result<Metadata, ArxivError>;
+pub trait PaperSource {
+    async fn exists(&self, id: &str) -> Result<bool, PaperSourceError>;
+    async fn get_source_archive(&self, id: &str) -> Result<Bytes, PaperSourceError>;
+    async fn get_pdf(&self, id: &str) -> Result<Bytes, PaperSourceError>;
+    async fn get_metadata(&self, id: &str) -> Result<Metadata, PaperSourceError>;
     async fn search(
         &self,
         _query: &str,
         _max_results: u32,
-    ) -> Result<Vec<SearchResult>, ArxivError> {
-        Err(ArxivError::NotImplemented)
+    ) -> Result<Vec<SearchResult>, PaperSourceError> {
+        Err(PaperSourceError::NotImplemented)
     }
 
-    async fn get_html_figure_image_urls(&self, _id: &str) -> Result<Vec<String>, ArxivError> {
+    async fn get_html_figure_image_urls(&self, _id: &str) -> Result<Vec<String>, PaperSourceError> {
         Ok(vec![])
     }
 }
+
+pub trait ArxivClient: PaperSource {}
+
+impl<T: PaperSource + ?Sized> ArxivClient for T {}
 
 pub struct ReqwestArxivClient {
     http: reqwest::Client,
@@ -50,19 +56,19 @@ impl ReqwestArxivClient {
 }
 
 #[async_trait]
-impl ArxivClient for ReqwestArxivClient {
-    async fn exists(&self, id: &str) -> Result<bool, ArxivError> {
+impl PaperSource for ReqwestArxivClient {
+    async fn exists(&self, id: &str) -> Result<bool, PaperSourceError> {
         let url = Url::parse_with_params("https://export.arxiv.org/api/query", &[("id_list", id)])
-            .map_err(|e| ArxivError::Network(e.to_string()))?;
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
         let res = self
             .http
             .get(url)
             .header(reqwest::header::ACCEPT, "application/atom+xml")
             .send()
             .await
-            .map_err(|e| ArxivError::Network(e.to_string()))?;
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
         if !res.status().is_success() {
-            return Err(ArxivError::Network(format!(
+            return Err(PaperSourceError::Network(format!(
                 "arXiv exists check HTTP {}",
                 res.status()
             )));
@@ -70,12 +76,12 @@ impl ArxivClient for ReqwestArxivClient {
         let body = res
             .text()
             .await
-            .map_err(|e| ArxivError::Network(e.to_string()))?;
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
         // Minimal parse: an empty feed has no <entry>; existing id yields at least one <entry>
         Ok(body.contains("<entry"))
     }
 
-    async fn get_source_archive(&self, id: &str) -> Result<Bytes, ArxivError> {
+    async fn get_source_archive(&self, id: &str) -> Result<Bytes, PaperSourceError> {
         let url = format!("https://arxiv.org/e-print/{}", id);
         let res = self
             .http
@@ -86,7 +92,7 @@ impl ArxivClient for ReqwestArxivClient {
             )
             .send()
             .await
-            .map_err(|e| ArxivError::Network(e.to_string()))?;
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
 
         let status = res.status();
         if status.is_success() {
@@ -101,15 +107,15 @@ impl ArxivClient for ReqwestArxivClient {
             let bytes = res
                 .bytes()
                 .await
-                .map_err(|e| ArxivError::Network(e.to_string()))?;
+                .map_err(|e| PaperSourceError::Network(e.to_string()))?;
 
             // If arXiv returns a PDF (no source available), map to PdfOnly
             if content_type.contains("application/pdf") || looks_like_pdf(&bytes) {
-                return Err(ArxivError::PdfOnly);
+                return Err(PaperSourceError::PdfOnly);
             }
             // Some upstream issues (e.g., HTML error pages) can slip through as 200s
             if content_type.contains("text/html") || looks_like_html(&bytes) {
-                return Err(ArxivError::Network(
+                return Err(PaperSourceError::Network(
                     "arXiv returned HTML when requesting e-print".into(),
                 ));
             }
@@ -118,15 +124,15 @@ impl ArxivClient for ReqwestArxivClient {
         }
         // Common cases: 400/403/404 when no source available → treat as PDF only
         if status.as_u16() == 400 || status.as_u16() == 403 || status.as_u16() == 404 {
-            return Err(ArxivError::PdfOnly);
+            return Err(PaperSourceError::PdfOnly);
         }
-        Err(ArxivError::Network(format!(
+        Err(PaperSourceError::Network(format!(
             "arXiv e-print HTTP {}",
             status
         )))
     }
 
-    async fn get_pdf(&self, id: &str) -> Result<Bytes, ArxivError> {
+    async fn get_pdf(&self, id: &str) -> Result<Bytes, PaperSourceError> {
         let url = format!("https://arxiv.org/pdf/{}.pdf", id);
         let res = self
             .http
@@ -134,45 +140,48 @@ impl ArxivClient for ReqwestArxivClient {
             .header(reqwest::header::ACCEPT, "application/pdf")
             .send()
             .await
-            .map_err(|e| ArxivError::Network(e.to_string()))?;
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
 
         let status = res.status();
         if status == reqwest::StatusCode::NOT_FOUND {
-            return Err(ArxivError::NotFound);
+            return Err(PaperSourceError::NotFound);
         }
         if !status.is_success() {
-            return Err(ArxivError::Network(format!("arXiv pdf HTTP {}", status)));
+            return Err(PaperSourceError::Network(format!(
+                "arXiv pdf HTTP {}",
+                status
+            )));
         }
 
         let bytes = res
             .bytes()
             .await
-            .map_err(|e| ArxivError::Network(e.to_string()))?;
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
 
         if looks_like_pdf(&bytes) {
             Ok(bytes)
         } else {
-            Err(ArxivError::Network(
+            Err(PaperSourceError::Network(
                 "unexpected non-PDF payload when requesting PDF".into(),
             ))
         }
     }
 
-    async fn get_metadata(&self, id: &str) -> Result<Metadata, ArxivError> {
+    async fn get_metadata(&self, id: &str) -> Result<Metadata, PaperSourceError> {
         let url = Url::parse_with_params("https://export.arxiv.org/api/query", &[("id_list", id)])
-            .map_err(|e| ArxivError::Network(e.to_string()))?;
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
         let res = self
             .http
             .get(url)
             .header(reqwest::header::ACCEPT, "application/atom+xml")
             .send()
             .await
-            .map_err(|e| ArxivError::Network(e.to_string()))?;
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
         if res.status() == reqwest::StatusCode::NOT_FOUND {
-            return Err(ArxivError::NotFound);
+            return Err(PaperSourceError::NotFound);
         }
         if !res.status().is_success() {
-            return Err(ArxivError::Network(format!(
+            return Err(PaperSourceError::Network(format!(
                 "arXiv metadata HTTP {}",
                 res.status()
             )));
@@ -180,15 +189,15 @@ impl ArxivClient for ReqwestArxivClient {
         let body = res
             .text()
             .await
-            .map_err(|e| ArxivError::Network(e.to_string()))?;
-        parse_atom_metadata(&body).ok_or(ArxivError::NotFound)
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
+        parse_atom_metadata(&body).ok_or(PaperSourceError::NotFound)
     }
 
     async fn search(
         &self,
         query: &str,
         max_results: u32,
-    ) -> Result<Vec<SearchResult>, ArxivError> {
+    ) -> Result<Vec<SearchResult>, PaperSourceError> {
         let max_results = max_results.min(50);
         let url = Url::parse_with_params(
             "https://export.arxiv.org/api/query",
@@ -198,7 +207,7 @@ impl ArxivClient for ReqwestArxivClient {
                 ("max_results", &max_results.to_string()),
             ],
         )
-        .map_err(|e| ArxivError::Network(e.to_string()))?;
+        .map_err(|e| PaperSourceError::Network(e.to_string()))?;
 
         let res = self
             .http
@@ -206,10 +215,10 @@ impl ArxivClient for ReqwestArxivClient {
             .header(reqwest::header::ACCEPT, "application/atom+xml")
             .send()
             .await
-            .map_err(|e| ArxivError::Network(e.to_string()))?;
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
 
         if !res.status().is_success() {
-            return Err(ArxivError::Network(format!(
+            return Err(PaperSourceError::Network(format!(
                 "arXiv search HTTP {}",
                 res.status()
             )));
@@ -218,27 +227,68 @@ impl ArxivClient for ReqwestArxivClient {
         let body = res
             .text()
             .await
-            .map_err(|e| ArxivError::Network(e.to_string()))?;
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
 
         Ok(parse_atom_search_results(&body))
     }
 
-    async fn get_html_figure_image_urls(&self, id: &str) -> Result<Vec<String>, ArxivError> {
+    async fn get_html_figure_image_urls(&self, id: &str) -> Result<Vec<String>, PaperSourceError> {
         let base_url = format!("https://arxiv.org/html/{}", id);
         let res = self
             .http
             .get(&base_url)
             .send()
             .await
-            .map_err(|e| ArxivError::Network(e.to_string()))?;
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
         if !res.status().is_success() {
             return Ok(vec![]);
         }
         let html = res
             .text()
             .await
-            .map_err(|e| ArxivError::Network(e.to_string()))?;
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
         Ok(parse_html_figure_image_urls(&html, &base_url))
+    }
+}
+
+pub fn normalize_arxiv_id(input: &str) -> Option<String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let candidate = if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        let url = Url::parse(trimmed).ok()?;
+        let host = url.host_str()?.to_ascii_lowercase();
+        if !host.ends_with("arxiv.org") {
+            return None;
+        }
+        let path = url.path().trim_matches('/');
+        path.strip_prefix("abs/")
+            .or_else(|| path.strip_prefix("pdf/"))
+            .or_else(|| path.strip_prefix("html/"))
+            .unwrap_or(path)
+            .to_string()
+    } else {
+        trimmed.to_string()
+    };
+
+    let candidate = strip_ascii_suffix(&candidate, ".pdf").unwrap_or(&candidate);
+    if candidate.is_empty() || !candidate.is_ascii() {
+        return None;
+    }
+    Some(candidate.to_string())
+}
+
+fn strip_ascii_suffix<'a>(input: &'a str, suffix: &str) -> Option<&'a str> {
+    if input.len() < suffix.len() {
+        return None;
+    }
+    let cut = input.len() - suffix.len();
+    if input.is_char_boundary(cut) && input[cut..].eq_ignore_ascii_case(suffix) {
+        Some(&input[..cut])
+    } else {
+        None
     }
 }
 
@@ -287,11 +337,7 @@ fn parse_atom_search_results(atom: &str) -> Vec<SearchResult> {
             .trim()
             .to_string();
         // Extract arXiv ID from full URL (e.g. "http://arxiv.org/abs/1706.03762v5" → "1706.03762v5")
-        let arxiv_id = id
-            .rsplit('/')
-            .next()
-            .unwrap_or(&id)
-            .to_string();
+        let arxiv_id = id.rsplit('/').next().unwrap_or(&id).to_string();
 
         if !title.is_empty() {
             results.push(SearchResult {
@@ -395,7 +441,10 @@ fn resolve_figure_img_url(base_url: &str, src: &str) -> String {
     // arXiv HTML pages can reference figure images as "<paper-id>vN/Figures/..."
     // even when the page URL is "/html/<paper-id>". In that case, joining with
     // "/html/<paper-id>/" duplicates the id segment, so anchor at "/html/".
-    if let Some(base_id) = base_url.path_segments().and_then(|mut segs| segs.next_back()) {
+    if let Some(base_id) = base_url
+        .path_segments()
+        .and_then(|mut segs| segs.next_back())
+    {
         let base_id_no_version = strip_version_suffix(base_id);
         let version_prefixed = src_trimmed.starts_with(&(base_id.to_string() + "/"))
             || src_trimmed.starts_with(&(base_id_no_version.to_string() + "v"));
@@ -573,13 +622,13 @@ pub mod test_helpers {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
-    pub struct MockArxivClient {
-        pub exists_response: Result<bool, ArxivError>,
-        pub archive_response: Result<Bytes, ArxivError>,
-        pub pdf_response: Result<Bytes, ArxivError>,
-        pub metadata_response: Result<Metadata, ArxivError>,
-        pub search_response: Result<Vec<SearchResult>, ArxivError>,
-        pub html_figure_urls_response: Result<Vec<String>, ArxivError>,
+    pub struct MockPaperSourceClient {
+        pub exists_response: Result<bool, PaperSourceError>,
+        pub archive_response: Result<Bytes, PaperSourceError>,
+        pub pdf_response: Result<Bytes, PaperSourceError>,
+        pub metadata_response: Result<Metadata, PaperSourceError>,
+        pub search_response: Result<Vec<SearchResult>, PaperSourceError>,
+        pub html_figure_urls_response: Result<Vec<String>, PaperSourceError>,
         pub exists_calls: Arc<AtomicUsize>,
         pub archive_calls: Arc<AtomicUsize>,
         pub pdf_calls: Arc<AtomicUsize>,
@@ -587,12 +636,14 @@ pub mod test_helpers {
         pub search_calls: Arc<AtomicUsize>,
     }
 
-    impl MockArxivClient {
+    pub type MockArxivClient = MockPaperSourceClient;
+
+    impl MockPaperSourceClient {
         pub fn new(
-            exists_response: Result<bool, ArxivError>,
-            archive_response: Result<Bytes, ArxivError>,
-            pdf_response: Result<Bytes, ArxivError>,
-            metadata_response: Result<Metadata, ArxivError>,
+            exists_response: Result<bool, PaperSourceError>,
+            archive_response: Result<Bytes, PaperSourceError>,
+            pdf_response: Result<Bytes, PaperSourceError>,
+            metadata_response: Result<Metadata, PaperSourceError>,
         ) -> Self {
             Self {
                 exists_response,
@@ -611,23 +662,23 @@ pub mod test_helpers {
     }
 
     #[async_trait]
-    impl ArxivClient for MockArxivClient {
-        async fn exists(&self, _id: &str) -> Result<bool, ArxivError> {
+    impl PaperSource for MockPaperSourceClient {
+        async fn exists(&self, _id: &str) -> Result<bool, PaperSourceError> {
             self.exists_calls.fetch_add(1, Ordering::SeqCst);
             self.exists_response.clone()
         }
 
-        async fn get_source_archive(&self, _id: &str) -> Result<Bytes, ArxivError> {
+        async fn get_source_archive(&self, _id: &str) -> Result<Bytes, PaperSourceError> {
             self.archive_calls.fetch_add(1, Ordering::SeqCst);
             self.archive_response.clone()
         }
 
-        async fn get_pdf(&self, _id: &str) -> Result<Bytes, ArxivError> {
+        async fn get_pdf(&self, _id: &str) -> Result<Bytes, PaperSourceError> {
             self.pdf_calls.fetch_add(1, Ordering::SeqCst);
             self.pdf_response.clone()
         }
 
-        async fn get_metadata(&self, _id: &str) -> Result<Metadata, ArxivError> {
+        async fn get_metadata(&self, _id: &str) -> Result<Metadata, PaperSourceError> {
             self.metadata_calls.fetch_add(1, Ordering::SeqCst);
             self.metadata_response.clone()
         }
@@ -636,12 +687,15 @@ pub mod test_helpers {
             &self,
             _query: &str,
             _max_results: u32,
-        ) -> Result<Vec<SearchResult>, ArxivError> {
+        ) -> Result<Vec<SearchResult>, PaperSourceError> {
             self.search_calls.fetch_add(1, Ordering::SeqCst);
             self.search_response.clone()
         }
 
-        async fn get_html_figure_image_urls(&self, _id: &str) -> Result<Vec<String>, ArxivError> {
+        async fn get_html_figure_image_urls(
+            &self,
+            _id: &str,
+        ) -> Result<Vec<String>, PaperSourceError> {
             self.html_figure_urls_response.clone()
         }
     }

--- a/src/biorxiv.rs
+++ b/src/biorxiv.rs
@@ -1,0 +1,349 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+use reqwest::Url;
+
+use crate::arxiv::{Metadata, PaperSource, PaperSourceError};
+
+const BIORXIV_HOST_SUFFIX: &str = "biorxiv.org";
+const BIORXIV_CONTENT_PREFIX: &str = "content/";
+
+pub struct ReqwestBiorxivClient {
+    http: reqwest::Client,
+}
+
+impl ReqwestBiorxivClient {
+    pub fn new() -> Self {
+        let http = reqwest::Client::builder()
+            .user_agent("markxiv/0.1 (+https://github.com/)")
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .expect("failed to build reqwest client");
+        Self { http }
+    }
+
+    fn article_url(id: &str) -> String {
+        format!("https://www.biorxiv.org/content/{}.full", id)
+    }
+
+    fn pdf_url(id: &str) -> String {
+        format!("https://www.biorxiv.org/content/{}.full.pdf", id)
+    }
+
+    async fn fetch_article_page(&self, id: &str) -> Result<String, PaperSourceError> {
+        let res = self
+            .http
+            .get(Self::article_url(id))
+            .send()
+            .await
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
+
+        if res.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(PaperSourceError::NotFound);
+        }
+        if !res.status().is_success() {
+            return Err(PaperSourceError::Network(format!(
+                "bioRxiv article HTTP {}",
+                res.status()
+            )));
+        }
+
+        res.text()
+            .await
+            .map_err(|e| PaperSourceError::Network(e.to_string()))
+    }
+}
+
+#[async_trait]
+impl PaperSource for ReqwestBiorxivClient {
+    async fn exists(&self, id: &str) -> Result<bool, PaperSourceError> {
+        match self.fetch_article_page(id).await {
+            Ok(_) => Ok(true),
+            Err(PaperSourceError::NotFound) => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn get_source_archive(&self, _id: &str) -> Result<Bytes, PaperSourceError> {
+        Err(PaperSourceError::PdfOnly)
+    }
+
+    async fn get_pdf(&self, id: &str) -> Result<Bytes, PaperSourceError> {
+        let res = self
+            .http
+            .get(Self::pdf_url(id))
+            .header(reqwest::header::ACCEPT, "application/pdf")
+            .send()
+            .await
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
+
+        if res.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(PaperSourceError::NotFound);
+        }
+        if !res.status().is_success() {
+            return Err(PaperSourceError::Network(format!(
+                "bioRxiv pdf HTTP {}",
+                res.status()
+            )));
+        }
+
+        let bytes = res
+            .bytes()
+            .await
+            .map_err(|e| PaperSourceError::Network(e.to_string()))?;
+
+        if bytes.starts_with(b"%PDF-") {
+            Ok(bytes)
+        } else {
+            Err(PaperSourceError::Network(
+                "unexpected non-PDF payload when requesting bioRxiv PDF".into(),
+            ))
+        }
+    }
+
+    async fn get_metadata(&self, id: &str) -> Result<Metadata, PaperSourceError> {
+        let html = self.fetch_article_page(id).await?;
+        parse_biorxiv_metadata(&html).ok_or(PaperSourceError::NotFound)
+    }
+}
+
+pub fn normalize_biorxiv_id(input: &str) -> Option<String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let candidate = if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        let url = Url::parse(trimmed).ok()?;
+        let host = url.host_str()?.to_ascii_lowercase();
+        if !host.ends_with(BIORXIV_HOST_SUFFIX) {
+            return None;
+        }
+        url.path().trim_matches('/').to_string()
+    } else {
+        trimmed.trim_start_matches('/').to_string()
+    };
+
+    let candidate = candidate
+        .strip_prefix(BIORXIV_CONTENT_PREFIX)
+        .unwrap_or(&candidate);
+    let candidate = strip_ascii_suffix(candidate, ".full.pdf")
+        .or_else(|| strip_ascii_suffix(candidate, ".full"))
+        .or_else(|| strip_ascii_suffix(candidate, ".pdf"))
+        .unwrap_or(candidate);
+
+    if candidate.is_empty() || !candidate.is_ascii() || !candidate.contains('/') {
+        return None;
+    }
+
+    Some(candidate.to_string())
+}
+
+pub fn canonical_biorxiv_path(id: &str) -> String {
+    format!("/bio/{}", id)
+}
+
+pub fn biorxiv_article_url(id: &str) -> String {
+    ReqwestBiorxivClient::article_url(id)
+}
+
+fn parse_biorxiv_metadata(html: &str) -> Option<Metadata> {
+    let title = extract_meta_value(html, &["citation_title", "dc.title", "og:title"])?;
+    let authors = extract_meta_values(html, &["citation_author"]);
+    let summary = extract_meta_value(
+        html,
+        &[
+            "citation_abstract",
+            "dc.description",
+            "description",
+            "og:description",
+        ],
+    )
+    .unwrap_or_default();
+
+    Some(Metadata {
+        title,
+        summary,
+        authors,
+    })
+}
+
+fn extract_meta_value(html: &str, names: &[&str]) -> Option<String> {
+    extract_meta_values(html, names).into_iter().next()
+}
+
+fn extract_meta_values(html: &str, names: &[&str]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut remainder = html;
+
+    while let Some(start) = remainder.find("<meta") {
+        let section = &remainder[start..];
+        let Some(end_rel) = section.find('>') else {
+            break;
+        };
+        let tag = &section[..=end_rel];
+        remainder = &section[end_rel + 1..];
+
+        let attrs = parse_meta_attributes(tag);
+        let Some(content) = attrs.get("content") else {
+            continue;
+        };
+        let Some(name) = attrs
+            .get("name")
+            .or_else(|| attrs.get("property"))
+            .map(|v| v.to_ascii_lowercase())
+        else {
+            continue;
+        };
+
+        if names
+            .iter()
+            .any(|candidate| name == candidate.to_ascii_lowercase())
+        {
+            let value = html_unescape(content).trim().to_string();
+            if !value.is_empty() {
+                out.push(value);
+            }
+        }
+    }
+
+    out
+}
+
+fn parse_meta_attributes(tag: &str) -> std::collections::HashMap<String, String> {
+    let mut attrs = std::collections::HashMap::new();
+    let bytes = tag.as_bytes();
+    let mut idx = 0;
+
+    while idx < bytes.len() {
+        while idx < bytes.len() && bytes[idx].is_ascii_whitespace() {
+            idx += 1;
+        }
+        if idx >= bytes.len() || matches!(bytes[idx], b'<' | b'>' | b'/') {
+            idx += 1;
+            continue;
+        }
+
+        let key_start = idx;
+        while idx < bytes.len()
+            && (bytes[idx].is_ascii_alphanumeric() || matches!(bytes[idx], b'-' | b'_' | b':'))
+        {
+            idx += 1;
+        }
+        if idx == key_start {
+            idx += 1;
+            continue;
+        }
+        let key = tag[key_start..idx].to_ascii_lowercase();
+
+        while idx < bytes.len() && bytes[idx].is_ascii_whitespace() {
+            idx += 1;
+        }
+        if idx >= bytes.len() || bytes[idx] != b'=' {
+            continue;
+        }
+        idx += 1;
+        while idx < bytes.len() && bytes[idx].is_ascii_whitespace() {
+            idx += 1;
+        }
+        if idx >= bytes.len() {
+            break;
+        }
+
+        let quote = bytes[idx];
+        if quote != b'"' && quote != b'\'' {
+            continue;
+        }
+        idx += 1;
+        let value_start = idx;
+        while idx < bytes.len() && bytes[idx] != quote {
+            idx += 1;
+        }
+        if idx <= bytes.len() {
+            attrs.insert(key, tag[value_start..idx].to_string());
+        }
+        idx += 1;
+    }
+
+    attrs
+}
+
+fn strip_ascii_suffix<'a>(input: &'a str, suffix: &str) -> Option<&'a str> {
+    if input.len() < suffix.len() {
+        return None;
+    }
+    let cut = input.len() - suffix.len();
+    if input.is_char_boundary(cut) && input[cut..].eq_ignore_ascii_case(suffix) {
+        Some(&input[..cut])
+    } else {
+        None
+    }
+}
+
+fn html_unescape(input: &str) -> String {
+    input
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_biorxiv_bare_id() {
+        assert_eq!(
+            normalize_biorxiv_id("10.1101/2024.01.02.123456v1").as_deref(),
+            Some("10.1101/2024.01.02.123456v1")
+        );
+    }
+
+    #[test]
+    fn normalize_biorxiv_full_suffix() {
+        assert_eq!(
+            normalize_biorxiv_id("10.1101/2024.01.02.123456v1.full").as_deref(),
+            Some("10.1101/2024.01.02.123456v1")
+        );
+    }
+
+    #[test]
+    fn normalize_biorxiv_full_pdf_suffix() {
+        assert_eq!(
+            normalize_biorxiv_id("10.1101/2024.01.02.123456v1.full.pdf").as_deref(),
+            Some("10.1101/2024.01.02.123456v1")
+        );
+    }
+
+    #[test]
+    fn normalize_biorxiv_url() {
+        assert_eq!(
+            normalize_biorxiv_id(
+                "https://www.biorxiv.org/content/10.1101/2024.01.02.123456v1.full.pdf"
+            )
+            .as_deref(),
+            Some("10.1101/2024.01.02.123456v1")
+        );
+    }
+
+    #[test]
+    fn parse_metadata_from_meta_tags() {
+        let html = r#"
+            <html>
+                <head>
+                    <meta name="citation_title" content="Sample bioRxiv paper" />
+                    <meta name="citation_author" content="Alice Example" />
+                    <meta name="citation_author" content="Bob Example" />
+                    <meta property="og:description" content="A concise abstract." />
+                </head>
+            </html>
+        "#;
+
+        let meta = parse_biorxiv_metadata(html).expect("metadata");
+        assert_eq!(meta.title, "Sample bioRxiv paper");
+        assert_eq!(meta.summary, "A concise abstract.");
+        assert_eq!(meta.authors, vec!["Alice Example", "Bob Example"]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod arxiv;
+pub mod biorxiv;
 pub mod cache;
 pub mod convert;
 pub mod disk_cache;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use axum::{routing::get, Router};
 use tower_http::trace::{DefaultMakeSpan, DefaultOnFailure, DefaultOnResponse, TraceLayer};
 
 use markxiv::arxiv::ReqwestArxivClient;
+use markxiv::biorxiv::ReqwestBiorxivClient;
 use markxiv::convert::PandocConverter;
 use markxiv::disk_cache::{DiskCache, DiskCacheConfig};
 use markxiv::routes;
@@ -134,7 +135,8 @@ async fn main() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(128);
 
-    let client = ReqwestArxivClient::new();
+    let arxiv_client = ReqwestArxivClient::new();
+    let biorxiv_client = ReqwestBiorxivClient::new();
     let converter = PandocConverter::new();
 
     // Optional disk cache
@@ -166,13 +168,15 @@ async fn main() {
         None
     };
 
-    let state = AppState::new(cache_cap, client, converter, disk);
+    let state =
+        AppState::new_with_clients(cache_cap, arxiv_client, biorxiv_client, converter, disk);
 
     let app = Router::new()
         .route("/", get(routes::index))
         .route("/health", get(routes::health))
         .route("/abs/:id", get(routes::paper))
-        .route("/pdf/:id", get(routes::paper))
+        .route("/pdf/:id", get(routes::pdf_paper))
+        .route("/bio/*id", get(routes::bio_paper))
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(DefaultMakeSpan::new().level(Level::INFO))

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,18 +1,18 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::{OriginalUri, Path, RawQuery, State},
+    extract::{Path, RawQuery, State},
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
 
 use crate::{
-    arxiv::{ArxivClient, ArxivError, Metadata},
-    cache::MkCache,
+    arxiv::{normalize_arxiv_id, Metadata, PaperSource, PaperSourceError},
+    biorxiv::{canonical_biorxiv_path, normalize_biorxiv_id},
     convert::{add_arxiv_figure_html_links, ConvertError, Converter},
-    disk_cache::DiskCache,
+    state::AppState,
 };
-use tokio::sync::{Mutex, Semaphore};
+use tokio::sync::Semaphore;
 
 pub async fn index(headers: HeaderMap) -> Response {
     let path = std::env::var("MARKXIV_INDEX_MD").unwrap_or_else(|_| "content/index.md".to_string());
@@ -81,30 +81,90 @@ pub async fn health() -> &'static str {
 }
 
 pub async fn paper(
-    State(cache): State<Arc<Mutex<MkCache>>>,
-    State(client): State<Arc<dyn ArxivClient + Send + Sync>>,
-    State(converter): State<Arc<dyn Converter + Send + Sync>>,
-    State(disk): State<Option<Arc<DiskCache>>>,
-    State(convert_limit): State<Arc<Semaphore>>,
+    State(state): State<AppState>,
     Path(raw_id): Path<String>,
-    original_uri: OriginalUri,
     raw_query: Option<RawQuery>,
 ) -> Response {
-    let trimmed = raw_id.trim();
-    let normalized = normalize_id(trimmed);
-
-    let original_path = original_uri.path().to_string();
-    let canonical_path = format!("/abs/{}", normalized);
-
-    // Minimal id validation: non-empty and ascii
-    if normalized.is_empty() || !normalized.is_ascii() {
+    let Some(id) = normalize_arxiv_id(&raw_id) else {
         return (StatusCode::BAD_REQUEST, "invalid id").into_response();
-    }
+    };
 
-    let id = normalized.to_string();
-    let cache_key = canonical_path.clone();
+    let content_location = format!("/abs/{}", id);
+    paper_with_provider(
+        &state,
+        ProviderRequest {
+            provider_name: "arXiv",
+            cache_namespace: "arxiv",
+            paper_id: id,
+            cache_path: content_location.clone(),
+            content_location,
+            client: state.arxiv_client.clone(),
+        },
+        parse_refresh(raw_query),
+    )
+    .await
+}
 
-    let refresh = raw_query
+pub async fn pdf_paper(
+    State(state): State<AppState>,
+    Path(raw_id): Path<String>,
+    raw_query: Option<RawQuery>,
+) -> Response {
+    let Some(id) = normalize_arxiv_id(&raw_id) else {
+        return (StatusCode::BAD_REQUEST, "invalid id").into_response();
+    };
+
+    paper_with_provider(
+        &state,
+        ProviderRequest {
+            provider_name: "arXiv",
+            cache_namespace: "arxiv",
+            paper_id: id.clone(),
+            cache_path: format!("/abs/{}", id),
+            content_location: format!("/pdf/{}", id),
+            client: state.arxiv_client.clone(),
+        },
+        parse_refresh(raw_query),
+    )
+    .await
+}
+
+pub async fn bio_paper(
+    State(state): State<AppState>,
+    Path(raw_id): Path<String>,
+    raw_query: Option<RawQuery>,
+) -> Response {
+    let Some(id) = normalize_biorxiv_id(&raw_id) else {
+        return (StatusCode::BAD_REQUEST, "invalid id").into_response();
+    };
+
+    let content_location = canonical_biorxiv_path(&id);
+    paper_with_provider(
+        &state,
+        ProviderRequest {
+            provider_name: "bioRxiv",
+            cache_namespace: "biorxiv",
+            paper_id: id,
+            cache_path: content_location.clone(),
+            content_location,
+            client: state.biorxiv_client.clone(),
+        },
+        parse_refresh(raw_query),
+    )
+    .await
+}
+
+struct ProviderRequest {
+    provider_name: &'static str,
+    cache_namespace: &'static str,
+    paper_id: String,
+    cache_path: String,
+    content_location: String,
+    client: Arc<dyn PaperSource + Send + Sync>,
+}
+
+fn parse_refresh(raw_query: Option<RawQuery>) -> bool {
+    raw_query
         .and_then(|q| q.0)
         .unwrap_or_default()
         .split('&')
@@ -118,17 +178,25 @@ pub async fn paper(
                 None
             }
         })
-        .is_some();
+        .is_some()
+}
+
+async fn paper_with_provider(
+    state: &AppState,
+    request: ProviderRequest,
+    refresh: bool,
+) -> Response {
+    let cache_key = format!("{}:{}", request.cache_namespace, request.cache_path);
 
     if !refresh {
-        if let Some(md) = cache.lock().await.get(&cache_key) {
-            return markdown_response(md, &original_path);
+        if let Some(md) = state.cache.lock().await.get(&cache_key) {
+            return markdown_response(md, &request.content_location);
         }
-        if let Some(dc) = &disk {
+        if let Some(dc) = &state.disk {
             match dc.get(&cache_key).await {
                 Ok(Some(md)) => {
-                    cache.lock().await.put(cache_key.clone(), md.clone());
-                    return markdown_response(md, &original_path);
+                    state.cache.lock().await.put(cache_key.clone(), md.clone());
+                    return markdown_response(md, &request.content_location);
                 }
                 Ok(None) => {}
                 Err(e) => tracing::error!(error = %e, "disk cache read error"),
@@ -136,29 +204,35 @@ pub async fn paper(
         }
     }
 
-    // Fetch metadata (title, abstract). If not implemented, continue without them.
-    let metadata = match client.get_metadata(&id).await {
+    let metadata = match request.client.get_metadata(&request.paper_id).await {
         Ok(m) => Some(m),
-        Err(err @ ArxivError::NotFound) => {
-            return map_arxiv_err("metadata", &id, err);
+        Err(err @ PaperSourceError::NotFound) => {
+            return map_source_err(request.provider_name, "metadata", &request.paper_id, err);
         }
-        Err(ArxivError::NotImplemented) => None,
+        Err(PaperSourceError::NotImplemented) => None,
         Err(err) => {
-            return map_arxiv_err("metadata", &id, err);
+            return map_source_err(request.provider_name, "metadata", &request.paper_id, err);
         }
     };
 
-    let (body_md, skip_metadata) = match client.get_source_archive(&id).await {
+    let (body_md, skip_metadata) = match request.client.get_source_archive(&request.paper_id).await
+    {
         Ok(bytes) => {
-            match convert_latex_with_retries(converter.as_ref(), &bytes, &id, convert_limit.clone())
-                .await
+            match convert_latex_with_retries(
+                state.converter.as_ref(),
+                &bytes,
+                &request.paper_id,
+                state.convert_limit.clone(),
+            )
+            .await
             {
                 Ok(s) => (s, false),
                 Err(_err) => match pdf_fallback(
-                    client.as_ref(),
-                    converter.as_ref(),
-                    &id,
-                    convert_limit.clone(),
+                    request.client.as_ref(),
+                    state.converter.as_ref(),
+                    &request.paper_id,
+                    state.convert_limit.clone(),
+                    request.provider_name,
                 )
                 .await
                 {
@@ -167,13 +241,14 @@ pub async fn paper(
                 },
             }
         }
-        Err(_err @ ArxivError::PdfOnly) => {
-            tracing::warn!(paper_id = %id, context = "source_archive", "arXiv reported PDF-only");
+        Err(_err @ PaperSourceError::PdfOnly) => {
+            tracing::warn!(paper_id = %request.paper_id, context = "source_archive", provider = request.provider_name, "provider reported PDF-only");
             match pdf_fallback(
-                client.as_ref(),
-                converter.as_ref(),
-                &id,
-                convert_limit.clone(),
+                request.client.as_ref(),
+                state.converter.as_ref(),
+                &request.paper_id,
+                state.convert_limit.clone(),
+                request.provider_name,
             )
             .await
             {
@@ -181,13 +256,19 @@ pub async fn paper(
                 Err(resp) => return resp,
             }
         }
-        Err(err) => return map_arxiv_err("source_archive", &id, err),
+        Err(err) => {
+            return map_source_err(
+                request.provider_name,
+                "source_archive",
+                &request.paper_id,
+                err,
+            )
+        }
     };
 
-    // Enrich figure placeholders with arxiv HTML image links (addresses #1).
-    // Falls back gracefully (no links) if the paper has no HTML version.
-    let figure_urls = client
-        .get_html_figure_image_urls(&id)
+    let figure_urls = request
+        .client
+        .get_html_figure_image_urls(&request.paper_id)
         .await
         .unwrap_or_default();
     let body_md = add_arxiv_figure_html_links(&body_md, &figure_urls);
@@ -200,23 +281,17 @@ pub async fn paper(
         body_md
     };
 
-    cache.lock().await.put(cache_key.clone(), final_md.clone());
-    if let Some(dc) = &disk {
+    state
+        .cache
+        .lock()
+        .await
+        .put(cache_key.clone(), final_md.clone());
+    if let Some(dc) = &state.disk {
         if let Err(e) = dc.put(&cache_key, &final_md).await {
             tracing::error!(error = %e, cache_key = %cache_key, "disk cache write error");
         }
     }
-    markdown_response(final_md, &original_path)
-}
-
-fn normalize_id(raw: &str) -> &str {
-    if raw.len() >= 4 {
-        let cut = raw.len() - 4;
-        if raw.is_char_boundary(cut) && raw[cut..].eq_ignore_ascii_case(".pdf") {
-            return &raw[..cut];
-        }
-    }
-    raw
+    markdown_response(final_md, &request.content_location)
 }
 
 fn markdown_response(md: String, content_location: &str) -> Response {
@@ -231,22 +306,22 @@ fn markdown_response(md: String, content_location: &str) -> Response {
     (StatusCode::OK, headers, md).into_response()
 }
 
-fn map_arxiv_err(context: &str, id: &str, e: ArxivError) -> Response {
+fn map_source_err(provider_name: &str, context: &str, id: &str, e: PaperSourceError) -> Response {
     match e {
-        ArxivError::NotFound => {
-            tracing::warn!(paper_id = %id, context = %context, "arXiv resource not found");
+        PaperSourceError::NotFound => {
+            tracing::warn!(paper_id = %id, context = %context, provider = provider_name, "provider resource not found");
             (StatusCode::NOT_FOUND, "not found").into_response()
         }
-        ArxivError::PdfOnly => {
-            tracing::warn!(paper_id = %id, context = %context, "arXiv provided PDF-only asset");
+        PaperSourceError::PdfOnly => {
+            tracing::warn!(paper_id = %id, context = %context, provider = provider_name, "provider provided PDF-only asset");
             (StatusCode::UNPROCESSABLE_ENTITY, "Error: PDF only").into_response()
         }
-        ArxivError::Network(msg) => {
-            tracing::error!(paper_id = %id, context = %context, error = %msg, "arXiv network error");
+        PaperSourceError::Network(msg) => {
+            tracing::error!(paper_id = %id, context = %context, provider = provider_name, error = %msg, "provider network error");
             (StatusCode::BAD_GATEWAY, msg).into_response()
         }
-        ArxivError::NotImplemented => {
-            tracing::warn!(paper_id = %id, context = %context, "arXiv feature not implemented");
+        PaperSourceError::NotImplemented => {
+            tracing::warn!(paper_id = %id, context = %context, provider = provider_name, "provider feature not implemented");
             (StatusCode::NOT_IMPLEMENTED, "not implemented").into_response()
         }
     }
@@ -266,14 +341,22 @@ fn map_convert_err(context: &str, id: &str, e: ConvertError) -> Response {
 }
 
 async fn pdf_fallback(
-    client: &(dyn ArxivClient + Send + Sync),
+    client: &(dyn PaperSource + Send + Sync),
     converter: &(dyn Converter + Send + Sync),
     id: &str,
     limit: Arc<Semaphore>,
+    provider_name: &str,
 ) -> Result<String, Response> {
     let pdf_bytes = match client.get_pdf(id).await {
         Ok(b) => b,
-        Err(err) => return Err(map_arxiv_err("pdf_fallback:get_pdf", id, err)),
+        Err(err) => {
+            return Err(map_source_err(
+                provider_name,
+                "pdf_fallback:get_pdf",
+                id,
+                err,
+            ))
+        }
     };
     let _permit = match limit.clone().acquire_owned().await {
         Ok(permit) => permit,
@@ -417,7 +500,7 @@ mod tests {
     use std::sync::atomic::Ordering;
     use tower::ServiceExt; // for `oneshot`
 
-    use crate::arxiv::test_helpers::MockArxivClient;
+    use crate::arxiv::{test_helpers::MockArxivClient, ArxivError};
     use crate::convert::test_helpers::MockConverter;
     use crate::state::AppState;
 
@@ -438,12 +521,15 @@ mod tests {
 
     #[test]
     fn normalize_id_strips_pdf_suffix_case_insensitively() {
-        assert_eq!(super::normalize_id("1234v1.PDF"), "1234v1");
+        assert_eq!(normalize_arxiv_id("1234v1.PDF").as_deref(), Some("1234v1"));
     }
 
     #[test]
     fn normalize_id_leaves_non_pdf_suffix() {
-        assert_eq!(super::normalize_id("1234v1.tar"), "1234v1.tar");
+        assert_eq!(
+            normalize_arxiv_id("1234v1.tar").as_deref(),
+            Some("1234v1.tar")
+        );
     }
 
     #[tokio::test]
@@ -468,8 +554,8 @@ mod tests {
     }
 
     #[test]
-    fn map_arxiv_err_translates_not_found() {
-        let resp = super::map_arxiv_err("metadata", "1234", ArxivError::NotFound);
+    fn map_source_err_translates_not_found() {
+        let resp = super::map_source_err("arXiv", "metadata", "1234", ArxivError::NotFound);
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
@@ -585,7 +671,7 @@ mod tests {
 
         let app = Router::new()
             .route("/abs/:id", get(super::paper))
-            .route("/pdf/:id", get(super::paper))
+            .route("/pdf/:id", get(super::pdf_paper))
             .with_state(state);
 
         let res = app
@@ -605,7 +691,7 @@ mod tests {
             .unwrap()
             .to_str()
             .unwrap();
-        assert_eq!(cl, format!("/pdf/{}.pdf", id));
+        assert_eq!(cl, format!("/pdf/{}", id));
         assert_eq!(metadata_calls.load(Ordering::SeqCst), 1);
         assert_eq!(archive_calls.load(Ordering::SeqCst), 1);
 
@@ -650,7 +736,7 @@ mod tests {
 
         let app = Router::new()
             .route("/abs/:id", get(super::paper))
-            .route("/pdf/:id", get(super::paper))
+            .route("/pdf/:id", get(super::pdf_paper))
             .with_state(state);
 
         let res = app
@@ -693,6 +779,70 @@ mod tests {
         assert_eq!(cl2, format!("/abs/{}", id));
         assert_eq!(metadata_calls.load(Ordering::SeqCst), 1);
         assert_eq!(archive_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn bio_route_normalizes_full_pdf_suffix_and_uses_separate_cache_namespace() {
+        let id = "10.1101/2024.01.02.123456v1";
+        let client = MockArxivClient::new(
+            Ok(true),
+            Err(ArxivError::PdfOnly),
+            Ok(Bytes::from_static(b"pdf-bytes")),
+            Ok(Metadata {
+                title: "Bio Paper".into(),
+                summary: "Abstract".into(),
+                authors: vec!["Author One".into()],
+            }),
+        );
+        let pdf_calls = client.pdf_calls.clone();
+        let converter = MockConverter::new(Ok(String::new()), Ok("bio pdf text".into()));
+        let state = AppState::new_with_clients(
+            8,
+            MockArxivClient::new(
+                Ok(true),
+                Err(ArxivError::NotImplemented),
+                Err(ArxivError::NotImplemented),
+                Err(ArxivError::NotImplemented),
+            ),
+            client,
+            converter,
+            None,
+        );
+
+        let app = Router::new()
+            .route("/bio/*id", get(super::bio_paper))
+            .with_state(state);
+
+        let res = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri(format!("/bio/{}.full.pdf", id))
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let cl = res
+            .headers()
+            .get(axum::http::header::CONTENT_LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(cl, format!("/bio/{}", id));
+
+        let res2 = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri(format!("/bio/{}.full", id))
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res2.status(), StatusCode::OK);
+        assert_eq!(pdf_calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
-use axum::extract::FromRef;
 use tokio::sync::{Mutex, Semaphore};
 
-use crate::arxiv::ArxivClient;
+use async_trait::async_trait;
+
+use crate::arxiv::{Metadata, PaperSource, PaperSourceError};
 use crate::cache::MkCache;
 use crate::convert::Converter;
 use crate::disk_cache::DiskCache;
@@ -11,7 +12,8 @@ use crate::disk_cache::DiskCache;
 #[derive(Clone)]
 pub struct AppState {
     pub cache: Arc<Mutex<MkCache>>,
-    pub client: Arc<dyn ArxivClient + Send + Sync>,
+    pub arxiv_client: Arc<dyn PaperSource + Send + Sync>,
+    pub biorxiv_client: Arc<dyn PaperSource + Send + Sync>,
     pub converter: Arc<dyn Converter + Send + Sync>,
     pub disk: Option<Arc<DiskCache>>,
     pub convert_limit: Arc<Semaphore>,
@@ -20,13 +22,29 @@ pub struct AppState {
 impl AppState {
     pub fn new<C, V>(cap: usize, client: C, converter: V, disk: Option<Arc<DiskCache>>) -> Self
     where
-        C: ArxivClient + Send + Sync + 'static,
+        C: PaperSource + Send + Sync + 'static,
+        V: Converter + Send + Sync + 'static,
+    {
+        Self::new_with_clients(cap, client, NullPaperSourceClient, converter, disk)
+    }
+
+    pub fn new_with_clients<A, B, V>(
+        cap: usize,
+        arxiv_client: A,
+        biorxiv_client: B,
+        converter: V,
+        disk: Option<Arc<DiskCache>>,
+    ) -> Self
+    where
+        A: PaperSource + Send + Sync + 'static,
+        B: PaperSource + Send + Sync + 'static,
         V: Converter + Send + Sync + 'static,
     {
         let permits = num_cpus::get().max(1);
         Self {
             cache: Arc::new(Mutex::new(MkCache::new(cap))),
-            client: Arc::new(client),
+            arxiv_client: Arc::new(arxiv_client),
+            biorxiv_client: Arc::new(biorxiv_client),
             converter: Arc::new(converter),
             disk,
             convert_limit: Arc::new(Semaphore::new(permits)),
@@ -34,32 +52,23 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for Arc<Mutex<MkCache>> {
-    fn from_ref(input: &AppState) -> Self {
-        input.cache.clone()
-    }
-}
+struct NullPaperSourceClient;
 
-impl FromRef<AppState> for Arc<dyn ArxivClient + Send + Sync> {
-    fn from_ref(input: &AppState) -> Self {
-        input.client.clone()
+#[async_trait]
+impl PaperSource for NullPaperSourceClient {
+    async fn exists(&self, _id: &str) -> Result<bool, PaperSourceError> {
+        Ok(false)
     }
-}
 
-impl FromRef<AppState> for Arc<dyn Converter + Send + Sync> {
-    fn from_ref(input: &AppState) -> Self {
-        input.converter.clone()
+    async fn get_source_archive(&self, _id: &str) -> Result<bytes::Bytes, PaperSourceError> {
+        Err(PaperSourceError::NotImplemented)
     }
-}
 
-impl FromRef<AppState> for Option<Arc<DiskCache>> {
-    fn from_ref(input: &AppState) -> Self {
-        input.disk.clone()
+    async fn get_pdf(&self, _id: &str) -> Result<bytes::Bytes, PaperSourceError> {
+        Err(PaperSourceError::NotImplemented)
     }
-}
 
-impl FromRef<AppState> for Arc<Semaphore> {
-    fn from_ref(input: &AppState) -> Self {
-        input.convert_limit.clone()
+    async fn get_metadata(&self, _id: &str) -> Result<Metadata, PaperSourceError> {
+        Err(PaperSourceError::NotImplemented)
     }
 }

--- a/tests/routes_integration.rs
+++ b/tests/routes_integration.rs
@@ -154,3 +154,108 @@ async fn refresh_query_triggers_pdf_fallback() {
     assert_eq!(latex_nomacro_calls.load(Ordering::SeqCst), 2);
     assert_eq!(converter_pdf_calls.load(Ordering::SeqCst), 2);
 }
+
+#[tokio::test]
+async fn biorxiv_route_uses_canonical_cache_key_and_reuses_disk_cache() {
+    let root = tmp_dir("biorxiv-disk-cache");
+    let cfg = DiskCacheConfig {
+        root: root.clone(),
+        cap_bytes: 1_000_000,
+        sweep_interval: Duration::from_secs(600),
+    };
+    let disk = DiskCache::new(cfg).await.unwrap();
+    let bio_id = "10.1101/2024.01.02.123456v1";
+
+    let arxiv_client = MockArxivClient::new(
+        Ok(true),
+        Err(ArxivError::NotImplemented),
+        Err(ArxivError::NotImplemented),
+        Err(ArxivError::NotImplemented),
+    );
+    let biorxiv_client = MockArxivClient::new(
+        Ok(true),
+        Err(ArxivError::PdfOnly),
+        Ok(Bytes::from_static(b"pdf-bytes")),
+        Ok(Metadata {
+            title: "Bio paper".into(),
+            summary: "Bio abstract".into(),
+            authors: vec!["Bio Author".into()],
+        }),
+    );
+    let pdf_calls = biorxiv_client.pdf_calls.clone();
+    let converter = MockConverter::new(Ok(String::new()), Ok("bio body".into()));
+
+    let state1 = AppState::new_with_clients(
+        8,
+        arxiv_client,
+        biorxiv_client,
+        converter,
+        Some(disk.clone()),
+    );
+    let app1 = Router::new()
+        .route("/bio/*id", get(routes::bio_paper))
+        .with_state(state1);
+
+    let res1 = app1
+        .oneshot(
+            Request::builder()
+                .uri(format!("/bio/{}.full.pdf", bio_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res1.status(), axum::http::StatusCode::OK);
+    assert_eq!(
+        res1.headers()
+            .get(axum::http::header::CONTENT_LOCATION)
+            .and_then(|value| value.to_str().ok()),
+        Some(format!("/bio/{}", bio_id).as_str())
+    );
+    let body1 = to_bytes(res1.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(body1.as_ref(), b"bio body");
+    assert_eq!(pdf_calls.load(Ordering::SeqCst), 1);
+
+    let arxiv_client2 = MockArxivClient::new(
+        Ok(true),
+        Err(ArxivError::NotImplemented),
+        Err(ArxivError::NotImplemented),
+        Err(ArxivError::NotImplemented),
+    );
+    let biorxiv_client2 = MockArxivClient::new(
+        Ok(true),
+        Err(ArxivError::Network("should not fetch".into())),
+        Err(ArxivError::Network("should not fetch".into())),
+        Err(ArxivError::Network("should not fetch".into())),
+    );
+    let pdf_calls2 = biorxiv_client2.pdf_calls.clone();
+    let state2 = AppState::new_with_clients(
+        8,
+        arxiv_client2,
+        biorxiv_client2,
+        MockConverter::new(
+            Err(ConvertError::Failed("should not convert".into())),
+            Err(ConvertError::Failed("should not convert".into())),
+        ),
+        Some(disk.clone()),
+    );
+    let app2 = Router::new()
+        .route("/bio/*id", get(routes::bio_paper))
+        .with_state(state2);
+
+    let res2 = app2
+        .oneshot(
+            Request::builder()
+                .uri(format!("/bio/{}.full", bio_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res2.status(), axum::http::StatusCode::OK);
+    let body2 = to_bytes(res2.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(body2.as_ref(), b"bio body");
+    assert_eq!(pdf_calls2.load(Ordering::SeqCst), 0);
+
+    let _ = tokio::fs::remove_dir_all(root).await;
+}


### PR DESCRIPTION
biorxiv papers are not available as LaTeX unfortunately. They do provide an XML so that would be nice to add in a future PR instead of relying on PDF parsing.